### PR TITLE
fix(persistence): sync Informe with real progress + PremiumModal Radar IA

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -599,12 +599,14 @@ export default function App() {
     } catch { /* silencioso */ }
   }
 
-  // Saves a CV version only if content changed since last save (prevents export duplicates)
-  const saveCvToHistorial = (cv, titulo) => {
+  // Saves a CV version only if content changed since last save (prevents export duplicates).
+  // Embeds quality assessment as _quality so it can be restored next session without re-scoring.
+  const saveCvToHistorial = (cv, titulo, quality = null) => {
     const hash = cv ? JSON.stringify(cv).slice(0, 400) : null
     if (!hash || hash === lastSavedCvHashRef.current) return
     lastSavedCvHashRef.current = hash
-    saveToHistorial('cv', cv, titulo, null)
+    const datos = quality ? { ...cv, _quality: quality } : cv
+    saveToHistorial('cv', datos, titulo, quality?.score ?? null)
   }
 
   const addToast = (msg, type = 'success', duration = 4000) => {
@@ -698,18 +700,27 @@ export default function App() {
         const latestAnalisis = historial.find(i => i.tipo === 'analisis')
         if (latestAnalisis) setResult(latestAnalisis.datos)
         else setResult(null)
-        setCvFinalData(item.datos)
-        setCvDraft(item.datos)
+        const cvDatos = item.datos
+        setCvFinalData(cvDatos)
+        setCvDraft(cvDatos)
+        setCvQuality(cvDatos?._quality || null)
         // Use refs (always-current) so photo is never stale even if closure timing is off.
         // The reactive useEffect will also re-run when cvFinalData/profilePhoto settle.
-        setCvPreviewHtml(buildCvHtml(item.datos, profilePhotoRef.current, profilePhotoMimeRef.current, cvTemplate || 'clasico'))
+        setCvPreviewHtml(buildCvHtml(cvDatos, profilePhotoRef.current, profilePhotoMimeRef.current, cvTemplate || 'clasico'))
         setCvStage('done')
         setShowCvPreview(true)
         setStep(STEPS.CV)
         break
       }
-      case 'entrevista':
-        setInterviewFeedback(item.datos?.feedback || item.datos)
+      case 'entrevista': {
+        const ef = item.datos?.feedback
+        if (ef) {
+          setInterviewFeedback(ef)
+        } else if (item.datos?.summary) {
+          setInterviewFeedback({ ...item.datos.summary, puntaje_entrevista: item.datos.summary.score ?? item.puntaje })
+        } else {
+          setInterviewFeedback(item.datos)
+        }
         setInterviewAnswers(item.datos?.respuestas || [])
         setStep(STEPS.INTERVIEW_FEEDBACK)
         break
@@ -721,21 +732,36 @@ export default function App() {
   // Hydrates result, cvFinalData, and interviewFeedback from historial, then navigates to MODE_SELECT.
   // Called when a returning PRO user clicks "Seguir con tu preparación" and result is not yet in session.
   const resumePreparation = () => {
-    const analisisItem = historial.find(i => i.tipo === 'analisis')
-    const cvItem = historial.find(i => i.tipo === 'cv')
+    const analisisItem  = historial.find(i => i.tipo === 'analisis')
+    const cvItem        = historial.find(i => i.tipo === 'cv')
     const interviewItem = historial.find(i => i.tipo === 'entrevista')
+    const starItem      = historial.find(i => i.tipo === 'star')
 
     if (analisisItem) setResult(analisisItem.datos)
 
     if (cvItem) {
-      setCvFinalData(cvItem.datos)
-      setCvDraft(cvItem.datos)
-      setCvStage('done')  // triggers useEffect at line 1147 to rebuild cvPreviewHtml
+      const cvDatos = cvItem.datos
+      setCvFinalData(cvDatos)
+      setCvDraft(cvDatos)
+      setCvQuality(cvDatos?._quality || null)
+      setCvStage('done')  // triggers useEffect to rebuild cvPreviewHtml
     }
 
     if (interviewItem) {
-      setInterviewFeedback(interviewItem.datos?.feedback || interviewItem.datos)
+      const ef = interviewItem.datos?.feedback
+      if (ef) {
+        setInterviewFeedback(ef)
+      } else if (interviewItem.datos?.summary) {
+        setInterviewFeedback({ ...interviewItem.datos.summary, puntaje_entrevista: interviewItem.datos.summary.score ?? interviewItem.puntaje })
+      } else {
+        setInterviewFeedback(interviewItem.datos)
+      }
       setInterviewAnswers(interviewItem.datos?.respuestas || [])
+    }
+
+    if (starItem && starItem.puntaje != null) {
+      const lastQ = starItem.datos?.preguntas?.slice(-1)[0]
+      setStarFeedback(lastQ?.feedback_star || { puntaje: starItem.puntaje })
     }
 
     setStep(STEPS.MODE_SELECT)
@@ -2137,7 +2163,7 @@ Generá el feedback en este JSON exacto:
       const titulo = variant === 'optimizado'
         ? `CV optimizado — ${newData.nombre || 'CV'}`
         : newData.nombre || 'CV'
-      saveCvToHistorial(newData, titulo)
+      saveCvToHistorial(newData, titulo, cvQuality)
       if (user?.es_premium) {
         setCvSuccess('✓ Versión guardada en historial')
         setTimeout(() => setCvSuccess(''), 3000)
@@ -2149,7 +2175,7 @@ Generá el feedback en este JSON exacto:
   const saveCvSnapshot = () => {
     if (!cvFinalData) return
     const titulo = cvFinalData.nombre || 'CV guardado'
-    saveCvToHistorial(cvFinalData, titulo)
+    saveCvToHistorial(cvFinalData, titulo, cvQuality)
     if (user?.es_premium) {
       setCvSuccess('✓ Versión guardada')
       setTimeout(() => setCvSuccess(''), 3000)
@@ -2239,7 +2265,7 @@ Generá el feedback en este JSON exacto:
         setCvVariant(null)
         setCvStage('done')
         setCvBaselineScore(quality?.score ?? null)
-        saveCvToHistorial(cv, cv.nombre || 'CV base')
+        saveCvToHistorial(cv, cv.nombre || 'CV base', quality)
         setCvPreviewHtml(buildCvHtml(cv, profilePhotoRef.current, profilePhotoMimeRef.current, cvTemplate))
         setShowCvPreview(true)
       } else {
@@ -2299,7 +2325,7 @@ Generá el feedback en este JSON exacto:
       setCvFinalData(cv)
       setCvVariant(null)
       setCvStage('done')
-      saveCvToHistorial(cv, cv.nombre || 'CV base')
+      saveCvToHistorial(cv, cv.nombre || 'CV base', quality)
       setCvPreviewHtml(buildCvHtml(cv, profilePhotoRef.current, profilePhotoMimeRef.current, cvTemplate))
       setShowCvPreview(true)
       trackEvent('cv_regenerated', { answered_count: Object.keys(gapAnswers).length })
@@ -2333,7 +2359,7 @@ Generá el feedback en este JSON exacto:
     setCvFinalData(adaptedCv)
     setCvVariant({ empresa: empresa || null, cargo: cargo || null })
     if (adaptedQuality) setCvQuality(adaptedQuality)
-    saveCvToHistorial(adaptedCv, empresa ? `CV adaptado — ${empresa}` : 'CV adaptado')
+    saveCvToHistorial(adaptedCv, empresa ? `CV adaptado — ${empresa}` : 'CV adaptado', adaptedQuality)
     setCvPreviewHtml(buildCvHtml(adaptedCv, profilePhotoRef.current, profilePhotoMimeRef.current, cvTemplate))
     setShowCvPreview(true)
     setShowJobModal(false)

--- a/src/components/modals/PremiumModal.jsx
+++ b/src/components/modals/PremiumModal.jsx
@@ -11,12 +11,12 @@ export default function PremiumModal({ user, setShowPremiumModal, subscriptionLo
 
         {/* ── Header — price + plan name ── */}
         <div className="p-6 sm:p-8 text-white" style={{ background: 'linear-gradient(135deg, #0d1f2d 0%, #1a3a5c 60%, #0d3055 100%)' }}>
-          <p className="text-xs font-semibold opacity-60 mb-1 tracking-widest">PLAN PROFESIONAL</p>
+          <p className="text-xs font-semibold opacity-60 mb-1 tracking-widest uppercase">Sistema de Empleabilidad IA</p>
           <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3">
             <div>
               <h2 className="text-2xl font-bold tracking-tight">Plan Profesional ✦</h2>
-              <p className="text-xs opacity-60 mt-1">Menos que un café por semana</p>
-              <p className="text-sm opacity-75 mt-0.5">Cancelás antes del día 7 y no te cobramos nada</p>
+              <p className="text-sm opacity-75 mt-1">La IA trabaja activamente en tu empleabilidad</p>
+              <p className="text-xs opacity-55 mt-0.5">Cancelás antes del día 7, no se cobra nada</p>
             </div>
             <div className="flex items-baseline gap-2 shrink-0">
               <p className="text-4xl font-bold">$3.000<span className="text-lg font-normal opacity-80">/mes</span></p>
@@ -26,40 +26,42 @@ export default function PremiumModal({ user, setShowPremiumModal, subscriptionLo
         </div>
 
         <div className="p-5 sm:p-8 space-y-4 bg-white">
-          {/* RI Teaser */}
+          {/* Radar hero teaser */}
           <div style={{
-            background: 'linear-gradient(135deg, #0d2137 0%, #0c3a5e 100%)',
+            background: 'linear-gradient(135deg, #0d2137 0%, #7b0d2f 100%)',
             borderRadius: 16,
             padding: '14px 16px',
-            marginBottom: 16,
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'space-between',
+            gap: 12,
           }}>
             <div>
               <p style={{ fontSize: 10, fontWeight: 700, color: 'rgba(255,255,255,0.6)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 3 }}>
-                Índice de Preparación
+                📡 Radar Laboral IA
               </p>
-              <p style={{ fontSize: 11, color: 'rgba(255,255,255,0.5)' }}>
-                Evolución de tu competitividad
+              <p style={{ fontSize: 13, fontWeight: 700, color: 'white', marginBottom: 2 }}>
+                La IA busca oportunidades por vos
+              </p>
+              <p style={{ fontSize: 11, color: 'rgba(255,255,255,0.55)', lineHeight: 1.4 }}>
+                Analiza el mercado en tiempo real · % de fit · brechas concretas
               </p>
             </div>
-            <div style={{ display: 'flex', alignItems: 'baseline', gap: 2 }}>
-              <span style={{ fontSize: 36, fontWeight: 800, color: 'white', letterSpacing: '-0.03em' }}>—</span>
-              <span style={{ fontSize: 14, color: 'rgba(255,255,255,0.5)' }}>/10</span>
-            </div>
+            <span style={{ fontSize: 28, opacity: 0.9, flexShrink: 0 }}>📡</span>
           </div>
 
           <p className="text-xs font-semibold text-slate-400 uppercase tracking-widest text-center">
-            Lo que incluye el Plan Profesional
+            Todo lo que incluye
           </p>
 
           <ul className="grid grid-cols-1 sm:grid-cols-2 gap-2">
             {[
-              ['🏆', 'Entrenamiento continuo', 'Historial ilimitado de sesiones de entrevista, STAR y análisis — mejorás de forma medible.'],
-              ['📄', 'CV re-descargable', 'Generá versiones y descargalas en cualquier momento, sin rehacer el proceso.'],
-              ['📍', 'Centro de operaciones', 'Kanban para trackear todas tus búsquedas activas y vincular el CV adaptado a cada una.'],
-              ['🎯', 'Índice de Preparación', 'Seguí la evolución de tu competitividad con cada sesión de entrenamiento.'],
+              ['📡', 'Radar Laboral IA', 'Búsqueda inteligente: matching por perfil, empresas objetivo, expansión IA y pipeline de oportunidades.'],
+              ['🏆', 'Entrenamiento continuo', 'Historial ilimitado de entrevistas, STAR y diagnósticos — mejorás de sesión en sesión.'],
+              ['📄', 'CV descargable + versiones', 'Descargá tu CV, guardá versiones adaptadas y exportalas cuando quieras.'],
+              ['📍', 'Pipeline de postulaciones', 'Kanban para trackear cada proceso activo y vincular el CV adaptado a cada búsqueda.'],
+              ['💡', 'Informe de preparación', 'Índice evolutivo de competitividad con desglose de todos tus módulos completados.'],
+              ['⚡', 'Adaptación táctica ilimitada', 'Adaptá tu CV a cada oferta en segundos con IA. Sin límite de postulaciones.'],
             ].map(([icon, title, desc]) => (
               <li key={title} className="flex gap-3 card-depth" style={{ background: '#f8fafc', borderRadius: 10, padding: '10px 12px' }}>
                 <span className="text-xl shrink-0">{icon}</span>
@@ -103,11 +105,11 @@ export default function PremiumModal({ user, setShowPremiumModal, subscriptionLo
             {subscriptionLoading ? 'Procesando...' : 'Activar Plan Profesional → 7 días gratis'}
           </button>
           <p className="text-center text-xs text-slate-400 -mt-1">
-            La versión gratuita es completa. El Plan Profesional agrega historial y entrenamiento continuo.
+            La versión gratuita es funcional. El Plan Profesional activa el Radar IA, historial, pipeline y entrenamiento continuo.
           </p>
           <button onClick={() => setShowPremiumModal(false)}
             className="w-full py-2 text-sm text-slate-400 text-center">
-            Ahora no, continuar sin guardar progreso
+            Ahora no, continuar sin Plan Profesional
           </button>
 
           {!showCouponField ? (

--- a/src/components/screens/ModeSelectScreen.jsx
+++ b/src/components/screens/ModeSelectScreen.jsx
@@ -61,7 +61,7 @@ function RadarStepCard({
 
   return (
     <div
-      className={`rounded-2xl transition-all duration-200 overflow-hidden step-card card-depth ${isRec ? 'shadow-md' : ''}`}
+      className={`rounded-2xl transition-all duration-200 overflow-hidden step-card card-depth md:h-full md:flex md:flex-col ${isRec ? 'shadow-md' : ''}`}
       style={{
         border: cardBorder,
         background: cardBg,
@@ -87,8 +87,8 @@ function RadarStepCard({
         </div>
       )}
 
-      <div className="p-4 sm:p-6">
-        <div className="flex items-start gap-3">
+      <div className="p-4 sm:p-6 md:flex-1 md:flex md:flex-col">
+        <div className="flex items-start md:items-stretch gap-3 md:flex-1">
           {/* Icon + step number */}
           <div className="shrink-0 text-center w-10">
             <div
@@ -116,7 +116,7 @@ function RadarStepCard({
           </div>
 
           {/* Content */}
-          <div className="flex-1 min-w-0">
+          <div className="flex-1 min-w-0 md:flex md:flex-col">
             <div className="flex items-start justify-between gap-1.5">
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2 flex-wrap">
@@ -180,7 +180,7 @@ function RadarStepCard({
             {!isLocked ? (
               <button
                 onClick={onClick}
-                className={`mt-3 spring-tap font-semibold text-xs transition-all ${isRec ? 'w-full py-3 rounded-xl text-white' : hasSavedJobs ? 'py-1.5 px-3 rounded-lg' : 'py-2 px-3.5 rounded-xl'}`}
+                className={`mt-3 md:mt-auto spring-tap font-semibold text-xs transition-all ${isRec ? 'w-full py-3 rounded-xl text-white' : hasSavedJobs ? 'py-1.5 px-3 rounded-lg' : 'py-2 px-3.5 rounded-xl'}`}
                 style={isRec
                   ? { background: `linear-gradient(135deg, #c2185b, #ad1457)`, boxShadow: `0 4px 16px rgba(194,24,91,0.30)` }
                   : hasSavedJobs
@@ -196,7 +196,7 @@ function RadarStepCard({
                 }
               </button>
             ) : (
-              <p className="text-[10px] text-slate-400 mt-2">🔒 Disponible cuando tengas tu CV</p>
+              <p className="text-[10px] text-slate-400 mt-2 md:mt-auto">🔒 Disponible cuando tengas tu CV</p>
             )}
           </div>
         </div>
@@ -500,7 +500,7 @@ export default function ModeSelectScreen({
       )}
 
       {/* Journey steps */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-2 stagger-in">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 stagger-in">
         {steps.map(s => {
           const isRec    = s.num === nextRec
           const isLocked = !s.available
@@ -525,9 +525,9 @@ export default function ModeSelectScreen({
 
           // ── Generic step card ────────────────────────────────────────────
           return (
-            <div key={s.num}>
+            <div key={s.num} className="flex flex-col">
               <div
-                className={`rounded-2xl transition-all duration-200 overflow-hidden step-card card-depth ${isRec ? 'shadow-md' : ''}`}
+                className={`rounded-2xl transition-all duration-200 overflow-hidden step-card card-depth md:flex-1 md:flex md:flex-col ${isRec ? 'shadow-md' : ''}`}
                 style={{
                   border: isRec
                     ? `1.5px solid ${s.ac}`
@@ -563,8 +563,8 @@ export default function ModeSelectScreen({
                   </div>
                 )}
 
-                <div className="p-4 sm:p-6">
-                  <div className="flex items-start gap-3">
+                <div className="p-4 sm:p-6 md:flex-1 md:flex md:flex-col">
+                  <div className="flex items-start md:items-stretch gap-3 md:flex-1">
                     {/* Icon + step number */}
                     <div className="shrink-0 text-center w-10">
                       <div className="w-10 h-10 rounded-xl flex items-center justify-center text-xl"
@@ -578,7 +578,7 @@ export default function ModeSelectScreen({
                     </div>
 
                     {/* Content */}
-                    <div className="flex-1 min-w-0">
+                    <div className="flex-1 min-w-0 md:flex md:flex-col">
                       <div className="flex items-start justify-between gap-1.5">
                         <div className="flex-1 min-w-0">
                           <div className="flex items-center gap-2 flex-wrap">
@@ -618,7 +618,7 @@ export default function ModeSelectScreen({
                           <button
                             onClick={s.onClick}
                             disabled={s.num === 6 && jobAdapterCheckLoading}
-                            className={`mt-3 spring-tap font-semibold text-xs transition-all ${isRec ? 'w-full py-3 rounded-xl text-white' : s.done ? 'py-1.5 px-3 rounded-lg' : 'py-2 px-3.5 rounded-xl'}`}
+                            className={`mt-3 md:mt-auto spring-tap font-semibold text-xs transition-all ${isRec ? 'w-full py-3 rounded-xl text-white' : s.done ? 'py-1.5 px-3 rounded-lg' : 'py-2 px-3.5 rounded-xl'}`}
                             style={isRec
                               ? { background: s.ac, boxShadow: `0 4px 14px ${s.aborder}` }
                               : s.done
@@ -639,7 +639,7 @@ export default function ModeSelectScreen({
                           )}
                         </>
                       ) : (
-                        <p className="text-[10px] text-slate-400 mt-2">🔒 {s.lockedLabel}</p>
+                        <p className="text-[10px] text-slate-400 mt-2 md:mt-auto">🔒 {s.lockedLabel}</p>
                       )}
                     </div>
                   </div>


### PR DESCRIPTION
## Problema resuelto

El "Informe de preparación" no reflejaba el estado real del usuario al volver en una nueva sesión — mostraba módulos como "no completados" aunque estuvieran hechos.

## Bugs corregidos (3 root causes)

### 1. `cvQuality` nunca se persistía en historial
- `saveCvToHistorial` guardaba solo el CV data, no el quality assessment
- Al restaurar, `cvFinalData` se recuperaba pero `cvQuality` quedaba `null`
- Resultado: Informe mostraba "CV Profesional: módulo no completado" aunque el CV estuviera generado
- **Fix:** `saveCvToHistorial(cv, titulo, quality)` embebe quality como `_quality` en el dato. Ambos paths de restauración (`resumePreparation` y `restoreFromHistorial`) ahora llaman `setCvQuality`

### 2. `starFeedback` nunca se restauraba
- `resumePreparation()` no leía el historial de tipo `'star'`
- El score STAR no aparecía en el `readinessIndex` en sesiones siguientes
- **Fix:** restaura el último ítem `'star'` → `setStarFeedback(lastQ?.feedback_star || { puntaje: starItem.puntaje })`

### 3. Interview formato 2 (`{summary,mode}`) no normalizaba `puntaje_entrevista`
- Las entrevistas en modo chat guardan `{ summary, mode }` en lugar de `{ feedback, respuestas }`
- Al restaurar: `interviewItem.datos?.feedback` = undefined → caía al objeto completo sin `puntaje_entrevista`
- **Fix:** ambos paths detectan el formato y mapean `summary.score → puntaje_entrevista`

## PremiumModal — copy actualizado

- **Header:** "Sistema de Empleabilidad IA" en lugar de framing genérico
- **Radar hero teaser:** protagonista visual en lugar del RI teaser genérico
- **Features:** 4 → 6 items, Radar Laboral IA primero, agregados Pipeline y Adaptación táctica ilimitada
- **Disclaimer:** nombra features específicos, no "historial y entrenamiento"
- **CTA cancelar:** "continuar sin Plan Profesional" (más claro)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K62FfrKMUyJxcxLkywS3oU)_