### PR TITLE
fix(radar): Serper diagnostics, expansion observability, Google Jobs UX signal

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -724,6 +724,7 @@ export default function App() {
         setInterviewAnswers(item.datos?.respuestas || [])
         setStep(STEPS.INTERVIEW_FEEDBACK)
         break
+      }
       default:
         break
     }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -599,12 +599,14 @@ export default function App() {
     } catch { /* silencioso */ }
   }
 
-  // Saves a CV version only if content changed since last save (prevents export duplicates)
-  const saveCvToHistorial = (cv, titulo) => {
+  // Saves a CV version only if content changed since last save (prevents export duplicates).
+  // Embeds quality assessment as _quality so it can be restored next session without re-scoring.
+  const saveCvToHistorial = (cv, titulo, quality = null) => {
     const hash = cv ? JSON.stringify(cv).slice(0, 400) : null
     if (!hash || hash === lastSavedCvHashRef.current) return
     lastSavedCvHashRef.current = hash
-    saveToHistorial('cv', cv, titulo, null)
+    const datos = quality ? { ...cv, _quality: quality } : cv
+    saveToHistorial('cv', datos, titulo, quality?.score ?? null)
   }
 
   const addToast = (msg, type = 'success', duration = 4000) => {
@@ -698,18 +700,27 @@ export default function App() {
         const latestAnalisis = historial.find(i => i.tipo === 'analisis')
         if (latestAnalisis) setResult(latestAnalisis.datos)
         else setResult(null)
-        setCvFinalData(item.datos)
-        setCvDraft(item.datos)
+        const cvDatos = item.datos
+        setCvFinalData(cvDatos)
+        setCvDraft(cvDatos)
+        setCvQuality(cvDatos?._quality || null)
         // Use refs (always-current) so photo is never stale even if closure timing is off.
         // The reactive useEffect will also re-run when cvFinalData/profilePhoto settle.
-        setCvPreviewHtml(buildCvHtml(item.datos, profilePhotoRef.current, profilePhotoMimeRef.current, cvTemplate || 'clasico'))
+        setCvPreviewHtml(buildCvHtml(cvDatos, profilePhotoRef.current, profilePhotoMimeRef.current, cvTemplate || 'clasico'))
         setCvStage('done')
         setShowCvPreview(true)
         setStep(STEPS.CV)
         break
       }
-      case 'entrevista':
-        setInterviewFeedback(item.datos?.feedback || item.datos)
+      case 'entrevista': {
+        const ef = item.datos?.feedback
+        if (ef) {
+          setInterviewFeedback(ef)
+        } else if (item.datos?.summary) {
+          setInterviewFeedback({ ...item.datos.summary, puntaje_entrevista: item.datos.summary.score ?? item.puntaje })
+        } else {
+          setInterviewFeedback(item.datos)
+        }
         setInterviewAnswers(item.datos?.respuestas || [])
         setStep(STEPS.INTERVIEW_FEEDBACK)
         break
@@ -721,21 +732,36 @@ export default function App() {
   // Hydrates result, cvFinalData, and interviewFeedback from historial, then navigates to MODE_SELECT.
   // Called when a returning PRO user clicks "Seguir con tu preparación" and result is not yet in session.
   const resumePreparation = () => {
-    const analisisItem = historial.find(i => i.tipo === 'analisis')
-    const cvItem = historial.find(i => i.tipo === 'cv')
+    const analisisItem  = historial.find(i => i.tipo === 'analisis')
+    const cvItem        = historial.find(i => i.tipo === 'cv')
     const interviewItem = historial.find(i => i.tipo === 'entrevista')
+    const starItem      = historial.find(i => i.tipo === 'star')
 
     if (analisisItem) setResult(analisisItem.datos)
 
     if (cvItem) {
-      setCvFinalData(cvItem.datos)
-      setCvDraft(cvItem.datos)
-      setCvStage('done')  // triggers useEffect at line 1147 to rebuild cvPreviewHtml
+      const cvDatos = cvItem.datos
+      setCvFinalData(cvDatos)
+      setCvDraft(cvDatos)
+      setCvQuality(cvDatos?._quality || null)
+      setCvStage('done')  // triggers useEffect to rebuild cvPreviewHtml
     }
 
     if (interviewItem) {
-      setInterviewFeedback(interviewItem.datos?.feedback || interviewItem.datos)
+      const ef = interviewItem.datos?.feedback
+      if (ef) {
+        setInterviewFeedback(ef)
+      } else if (interviewItem.datos?.summary) {
+        setInterviewFeedback({ ...interviewItem.datos.summary, puntaje_entrevista: interviewItem.datos.summary.score ?? interviewItem.puntaje })
+      } else {
+        setInterviewFeedback(interviewItem.datos)
+      }
       setInterviewAnswers(interviewItem.datos?.respuestas || [])
+    }
+
+    if (starItem && starItem.puntaje != null) {
+      const lastQ = starItem.datos?.preguntas?.slice(-1)[0]
+      setStarFeedback(lastQ?.feedback_star || { puntaje: starItem.puntaje })
     }
 
     setStep(STEPS.MODE_SELECT)
@@ -2137,7 +2163,7 @@ Generá el feedback en este JSON exacto:
       const titulo = variant === 'optimizado'
         ? `CV optimizado — ${newData.nombre || 'CV'}`
         : newData.nombre || 'CV'
-      saveCvToHistorial(newData, titulo)
+      saveCvToHistorial(newData, titulo, cvQuality)
       if (user?.es_premium) {
         setCvSuccess('✓ Versión guardada en historial')
         setTimeout(() => setCvSuccess(''), 3000)
@@ -2149,7 +2175,7 @@ Generá el feedback en este JSON exacto:
   const saveCvSnapshot = () => {
     if (!cvFinalData) return
     const titulo = cvFinalData.nombre || 'CV guardado'
-    saveCvToHistorial(cvFinalData, titulo)
+    saveCvToHistorial(cvFinalData, titulo, cvQuality)
     if (user?.es_premium) {
       setCvSuccess('✓ Versión guardada')
       setTimeout(() => setCvSuccess(''), 3000)
@@ -2239,7 +2265,7 @@ Generá el feedback en este JSON exacto:
         setCvVariant(null)
         setCvStage('done')
         setCvBaselineScore(quality?.score ?? null)
-        saveCvToHistorial(cv, cv.nombre || 'CV base')
+        saveCvToHistorial(cv, cv.nombre || 'CV base', quality)
         setCvPreviewHtml(buildCvHtml(cv, profilePhotoRef.current, profilePhotoMimeRef.current, cvTemplate))
         setShowCvPreview(true)
       } else {
@@ -2299,7 +2325,7 @@ Generá el feedback en este JSON exacto:
       setCvFinalData(cv)
       setCvVariant(null)
       setCvStage('done')
-      saveCvToHistorial(cv, cv.nombre || 'CV base')
+      saveCvToHistorial(cv, cv.nombre || 'CV base', quality)
       setCvPreviewHtml(buildCvHtml(cv, profilePhotoRef.current, profilePhotoMimeRef.current, cvTemplate))
       setShowCvPreview(true)
       trackEvent('cv_regenerated', { answered_count: Object.keys(gapAnswers).length })
@@ -2333,7 +2359,7 @@ Generá el feedback en este JSON exacto:
     setCvFinalData(adaptedCv)
     setCvVariant({ empresa: empresa || null, cargo: cargo || null })
     if (adaptedQuality) setCvQuality(adaptedQuality)
-    saveCvToHistorial(adaptedCv, empresa ? `CV adaptado — ${empresa}` : 'CV adaptado')
+    saveCvToHistorial(adaptedCv, empresa ? `CV adaptado — ${empresa}` : 'CV adaptado', adaptedQuality)
     setCvPreviewHtml(buildCvHtml(adaptedCv, profilePhotoRef.current, profilePhotoMimeRef.current, cvTemplate))
     setShowCvPreview(true)
     setShowJobModal(false)

--- a/src/components/modals/PremiumModal.jsx
+++ b/src/components/modals/PremiumModal.jsx
@@ -11,12 +11,12 @@ export default function PremiumModal({ user, setShowPremiumModal, subscriptionLo
 
         {/* ── Header — price + plan name ── */}
         <div className="p-6 sm:p-8 text-white" style={{ background: 'linear-gradient(135deg, #0d1f2d 0%, #1a3a5c 60%, #0d3055 100%)' }}>
-          <p className="text-xs font-semibold opacity-60 mb-1 tracking-widest">PLAN PROFESIONAL</p>
+          <p className="text-xs font-semibold opacity-60 mb-1 tracking-widest uppercase">Sistema de Empleabilidad IA</p>
           <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3">
             <div>
               <h2 className="text-2xl font-bold tracking-tight">Plan Profesional ✦</h2>
-              <p className="text-xs opacity-60 mt-1">Menos que un café por semana</p>
-              <p className="text-sm opacity-75 mt-0.5">Cancelás antes del día 7 y no te cobramos nada</p>
+              <p className="text-sm opacity-75 mt-1">La IA trabaja activamente en tu empleabilidad</p>
+              <p className="text-xs opacity-55 mt-0.5">Cancelás antes del día 7, no se cobra nada</p>
             </div>
             <div className="flex items-baseline gap-2 shrink-0">
               <p className="text-4xl font-bold">$3.000<span className="text-lg font-normal opacity-80">/mes</span></p>
@@ -26,40 +26,42 @@ export default function PremiumModal({ user, setShowPremiumModal, subscriptionLo
         </div>
 
         <div className="p-5 sm:p-8 space-y-4 bg-white">
-          {/* RI Teaser */}
+          {/* Radar hero teaser */}
           <div style={{
-            background: 'linear-gradient(135deg, #0d2137 0%, #0c3a5e 100%)',
+            background: 'linear-gradient(135deg, #0d2137 0%, #7b0d2f 100%)',
             borderRadius: 16,
             padding: '14px 16px',
-            marginBottom: 16,
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'space-between',
+            gap: 12,
           }}>
             <div>
               <p style={{ fontSize: 10, fontWeight: 700, color: 'rgba(255,255,255,0.6)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 3 }}>
-                Índice de Preparación
+                📡 Radar Laboral IA
               </p>
-              <p style={{ fontSize: 11, color: 'rgba(255,255,255,0.5)' }}>
-                Evolución de tu competitividad
+              <p style={{ fontSize: 13, fontWeight: 700, color: 'white', marginBottom: 2 }}>
+                La IA busca oportunidades por vos
+              </p>
+              <p style={{ fontSize: 11, color: 'rgba(255,255,255,0.55)', lineHeight: 1.4 }}>
+                Analiza el mercado en tiempo real · % de fit · brechas concretas
               </p>
             </div>
-            <div style={{ display: 'flex', alignItems: 'baseline', gap: 2 }}>
-              <span style={{ fontSize: 36, fontWeight: 800, color: 'white', letterSpacing: '-0.03em' }}>—</span>
-              <span style={{ fontSize: 14, color: 'rgba(255,255,255,0.5)' }}>/10</span>
-            </div>
+            <span style={{ fontSize: 28, opacity: 0.9, flexShrink: 0 }}>📡</span>
           </div>
 
           <p className="text-xs font-semibold text-slate-400 uppercase tracking-widest text-center">
-            Lo que incluye el Plan Profesional
+            Todo lo que incluye
           </p>
 
           <ul className="grid grid-cols-1 sm:grid-cols-2 gap-2">
             {[
-              ['🏆', 'Entrenamiento continuo', 'Historial ilimitado de sesiones de entrevista, STAR y análisis — mejorás de forma medible.'],
-              ['📄', 'CV re-descargable', 'Generá versiones y descargalas en cualquier momento, sin rehacer el proceso.'],
-              ['📍', 'Centro de operaciones', 'Kanban para trackear todas tus búsquedas activas y vincular el CV adaptado a cada una.'],
-              ['🎯', 'Índice de Preparación', 'Seguí la evolución de tu competitividad con cada sesión de entrenamiento.'],
+              ['📡', 'Radar Laboral IA', 'Búsqueda inteligente: matching por perfil, empresas objetivo, expansión IA y pipeline de oportunidades.'],
+              ['🏆', 'Entrenamiento continuo', 'Historial ilimitado de entrevistas, STAR y diagnósticos — mejorás de sesión en sesión.'],
+              ['📄', 'CV descargable + versiones', 'Descargá tu CV, guardá versiones adaptadas y exportalas cuando quieras.'],
+              ['📍', 'Pipeline de postulaciones', 'Kanban para trackear cada proceso activo y vincular el CV adaptado a cada búsqueda.'],
+              ['💡', 'Informe de preparación', 'Índice evolutivo de competitividad con desglose de todos tus módulos completados.'],
+              ['⚡', 'Adaptación táctica ilimitada', 'Adaptá tu CV a cada oferta en segundos con IA. Sin límite de postulaciones.'],
             ].map(([icon, title, desc]) => (
               <li key={title} className="flex gap-3 card-depth" style={{ background: '#f8fafc', borderRadius: 10, padding: '10px 12px' }}>
                 <span className="text-xl shrink-0">{icon}</span>
@@ -103,11 +105,11 @@ export default function PremiumModal({ user, setShowPremiumModal, subscriptionLo
             {subscriptionLoading ? 'Procesando...' : 'Activar Plan Profesional → 7 días gratis'}
           </button>
           <p className="text-center text-xs text-slate-400 -mt-1">
-            La versión gratuita es completa. El Plan Profesional agrega historial y entrenamiento continuo.
+            La versión gratuita es funcional. El Plan Profesional activa el Radar IA, historial, pipeline y entrenamiento continuo.
           </p>
           <button onClick={() => setShowPremiumModal(false)}
             className="w-full py-2 text-sm text-slate-400 text-center">
-            Ahora no, continuar sin guardar progreso
+            Ahora no, continuar sin Plan Profesional
           </button>
 
           {!showCouponField ? (

--- a/src/components/screens/JobRecommendationsScreen.jsx
+++ b/src/components/screens/JobRecommendationsScreen.jsx
@@ -155,8 +155,8 @@ const LOADING_STAGES = [
   },
   {
     icon: '✨',
-    msg: 'Explorando títulos alternativos y roles equivalentes',
-    sub: 'HRBP, People Partner, Tech Lead, Staff Engineer… variantes que los filtros normales no cubren.',
+    msg: 'Activando expansión IA · Google Jobs · sourcing avanzado',
+    sub: 'Generando términos alternativos y ampliando cobertura con Google Jobs + ATS premium para tu perfil.',
     premiumOnly: true,
   },
   {
@@ -1050,6 +1050,7 @@ export default function JobRecommendationsScreen({
   const [expansionCount, setExpansionCount]   = useState(0)
   const [candidateLoc, setCandidateLoc]       = useState(null)
   const [pipelineStats, setPipelineStats]     = useState(null)   // { sources_count, total_evaluated }
+  const [serperActive, setSerperActive]       = useState(false)  // Google Jobs ran this search
 
   // ── Analytics session refs ─────────────────────────────────────────────────
   // Track how many cards the user has seen and saved in this session
@@ -1202,6 +1203,7 @@ export default function JobRecommendationsScreen({
       setExpansionCount(data.expansion_count || 0)
       setCandidateLoc(data.candidate_location || null)
       setPipelineStats(data.pipeline_stats || null)
+      setSerperActive(data.pipeline_stats?.serper_in_sources || false)
       setLoadState('done')
 
       // 3. SEARCH COMPLETED — rich params enable source-level attribution and
@@ -1490,18 +1492,26 @@ export default function JobRecommendationsScreen({
               )}
             </div>
             {loadState === 'done' && (
-              <p className="text-[10px]" style={{ color: '#94a3b8' }}>
-                {pipelineStats?.sources_count
-                  ? `${pipelineStats.sources_count} fuentes`
-                  : null}
-                {pipelineStats?.sources_count && (pipelineStats?.total_evaluated || totalAnalyzed > 0) ? ' · ' : null}
-                {pipelineStats?.total_evaluated
-                  ? `${pipelineStats.total_evaluated.toLocaleString('es-AR')} avisos evaluados`
-                  : totalAnalyzed > 0
-                    ? `${totalAnalyzed} avisos evaluados`
+              <div className="flex items-center gap-1.5 flex-wrap">
+                <p className="text-[10px]" style={{ color: '#94a3b8' }}>
+                  {pipelineStats?.sources_count
+                    ? `${pipelineStats.sources_count} fuentes`
                     : null}
-                {fromCache ? ' · Caché de hoy' : ''}
-              </p>
+                  {pipelineStats?.sources_count && (pipelineStats?.total_evaluated || totalAnalyzed > 0) ? ' · ' : null}
+                  {pipelineStats?.total_evaluated
+                    ? `${pipelineStats.total_evaluated.toLocaleString('es-AR')} avisos evaluados`
+                    : totalAnalyzed > 0
+                      ? `${totalAnalyzed} avisos evaluados`
+                      : null}
+                  {fromCache ? ' · Caché de hoy' : ''}
+                </p>
+                {serperActive && (
+                  <span className="text-[9px] font-semibold px-1.5 py-0.5 rounded-full"
+                    style={{ background: 'rgba(66,133,244,0.10)', color: '#4285F4' }}>
+                    Google Jobs ✓
+                  </span>
+                )}
+              </div>
             )}
           </div>
           {/* Refresh button */}
@@ -1709,6 +1719,7 @@ export default function JobRecommendationsScreen({
                         {[
                           pipelineStats.sources_count ? `Analizadas ${pipelineStats.sources_count} fuentes` : null,
                           pipelineStats.total_evaluated ? `${pipelineStats.total_evaluated.toLocaleString('es-AR')} avisos evaluados` : null,
+                          serperActive ? '🔍 Google Jobs activado' : null,
                         ].filter(Boolean).join(' · ')}
                       </p>
                     ) : totalAnalyzed > filteredRecs.length ? (

--- a/src/components/screens/JobRecommendationsScreen.jsx
+++ b/src/components/screens/JobRecommendationsScreen.jsx
@@ -1042,8 +1042,9 @@ export default function JobRecommendationsScreen({
   const [quotaRemaining, setQuotaRem]     = useState(null)
   const [totalAnalyzed, setTotalAnalyzed] = useState(0)
   const [fromCache, setFromCache]         = useState(false)
-  const [cachedToday, setCachedToday]     = useState(false)
-  const [cacheTimestamp, setCacheTs]      = useState(null)
+  const [cachedToday, setCachedToday]         = useState(false)
+  const [cacheTimestamp, setCacheTs]          = useState(null)
+  const [servedFromHistory, setFromHistory]   = useState(false)
   const [expansionAvail, setExpansionAvail]   = useState(false)
   const [expansionUsed, setExpansionUsed]     = useState(false)
   const [expansionCount, setExpansionCount]   = useState(0)
@@ -1168,14 +1169,11 @@ export default function JobRecommendationsScreen({
 
       if (res.status === 429) {
         const data = await res.json().catch(() => ({}))
-        const isDaily = data?.quota_remaining === 0
         // Normalize error to string — worker can return {message:} objects in some paths
         const rawErr = data?.error
         const errStr = typeof rawErr === 'string' ? rawErr
-          : (rawErr?.message ? String(rawErr.message) : 'Límite de búsquedas alcanzado. Intentá en unos minutos.')
-        setError(isDaily
-          ? 'Usaste todas tus búsquedas de hoy. Volvé mañana para nuevas recomendaciones.'
-          : errStr)
+          : (rawErr?.message ? String(rawErr.message) : 'Error al buscar. Intentá de nuevo.')
+        setError(errStr)
         setLoadState('error')
         trackEvent('job_recommendations_rate_limited')
         return
@@ -1198,6 +1196,7 @@ export default function JobRecommendationsScreen({
       setFromCache(data.from_cache || false)
       setCachedToday(data.cached_today || false)
       setCacheTs(data.cache_timestamp || null)
+      setFromHistory(data.served_from_history || false)
       setExpansionAvail(data.expansion_available || false)
       setExpansionUsed(data.expansion_used || false)
       setExpansionCount(data.expansion_count || 0)
@@ -1659,20 +1658,18 @@ export default function JobRecommendationsScreen({
 
         {/* ── ERROR STATE ── */}
         {loadState === 'error' && (() => {
-          // Normalize defensively — error must be string for .includes() calls
           const errStr = typeof error === 'string' ? error : String(error?.message || error || '')
+          const isQuotaErr = errStr.includes('mes') || errStr.includes('mañana') || errStr.includes('búsqueda')
           return (
             <div className="text-center py-12 px-6 space-y-4">
-              <span className="text-4xl">
-                {errStr.includes('mañana') || errStr.includes('búsquedas') ? '⏳' : '⚠️'}
-              </span>
+              <span className="text-4xl">{isQuotaErr ? '⏳' : '⚠️'}</span>
               <h3 className="font-bold text-base" style={{ color: '#0d2137' }}>
-                {errStr.includes('mañana') ? 'Límite diario alcanzado' : 'Algo salió mal'}
+                {isQuotaErr ? 'Búsquedas agotadas por hoy' : 'Algo salió mal'}
               </h3>
               <p className="text-sm max-w-xs mx-auto leading-relaxed" style={{ color: '#64748b' }}>
                 {errStr || 'Ocurrió un error inesperado. Intentá de nuevo.'}
               </p>
-              {!errStr.includes('mañana') && (
+              {!isQuotaErr && (
                 <button
                   onClick={fetchRecommendations}
                   className="px-6 py-3 rounded-2xl text-sm font-semibold text-white"
@@ -1680,11 +1677,12 @@ export default function JobRecommendationsScreen({
                   Intentar de nuevo
                 </button>
               )}
-              {quotaRemaining !== null && (
+              {isQuotaErr && !isPremium && (
                 <p className="text-xs" style={{ color: '#94a3b8' }}>
-                  {isPremium
-                    ? `Premium: 1 búsqueda nueva por día · Los resultados del día se guardan`
-                    : `Plan gratuito: 1 búsqueda/mes · Actualizá a Premium para buscar diariamente`}
+                  Plan gratuito: 1 búsqueda/mes · Activá Premium para 5 búsquedas diarias
+                  <button onClick={() => setShowPremiumModal(true)} className="ml-1 underline" style={{ color: '#0077B5' }}>
+                    Activar
+                  </button>
                 </p>
               )}
             </div>
@@ -1742,21 +1740,25 @@ export default function JobRecommendationsScreen({
               </div>
             )}
 
-            {/* Cached-today banner */}
-            {cachedToday && cacheTimestamp && filteredRecs.length > 0 && (
+            {/* Cached/history banner — neutral UX for both same-day cache and history fallback */}
+            {(cachedToday || servedFromHistory) && cacheTimestamp && filteredRecs.length > 0 && (
               <div className="flex items-center gap-2 px-3 py-2 rounded-xl"
                 style={{ background: 'rgba(22,163,74,0.07)', border: '1px solid rgba(22,163,74,0.18)' }}>
                 <span className="text-xs shrink-0" style={{ color: '#16a34a' }}>✓</span>
                 <p className="text-xs flex-1" style={{ color: '#15803d' }}>
-                  Radar listo desde las{' '}
-                  {new Date(cacheTimestamp).toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' })}
+                  {servedFromHistory
+                    ? 'Continuando tu radar laboral'
+                    : `Radar listo desde las ${new Date(cacheTimestamp).toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' })}`
+                  }
                 </p>
-                <button
-                  onClick={() => { setCachedToday(false); setCacheTs(null); fetchRecommendations() }}
-                  className="text-[11px] font-semibold shrink-0 px-2 py-0.5 rounded-lg"
-                  style={{ color: '#0077B5', background: 'rgba(0,119,181,0.08)' }}>
-                  Actualizar
-                </button>
+                {!servedFromHistory && (
+                  <button
+                    onClick={() => { setCachedToday(false); setCacheTs(null); fetchRecommendations() }}
+                    className="text-[11px] font-semibold shrink-0 px-2 py-0.5 rounded-lg"
+                    style={{ color: '#0077B5', background: 'rgba(0,119,181,0.08)' }}>
+                    Actualizar
+                  </button>
+                )}
               </div>
             )}
 
@@ -2007,11 +2009,11 @@ export default function JobRecommendationsScreen({
               </div>
             )}
 
-            {/* Quota usage footer */}
-            {quotaRemaining !== null && filteredRecs.length > 0 && (
+            {/* Quota usage footer — hidden for premium when at 0 (served from history, no need to surface limits) */}
+            {quotaRemaining !== null && quotaRemaining > 0 && filteredRecs.length > 0 && (
               <p className="text-xs text-center py-4" style={{ color: '#cbd5e1' }}>
                 {isPremium
-                  ? `${quotaRemaining} búsquedas disponibles hoy`
+                  ? `${quotaRemaining} ${quotaRemaining === 1 ? 'búsqueda disponible' : 'búsquedas disponibles'} hoy`
                   : `${quotaRemaining} búsquedas gratuitas disponibles`}
                 {!isPremium && (
                   <button

--- a/src/components/screens/ModeSelectScreen.jsx
+++ b/src/components/screens/ModeSelectScreen.jsx
@@ -61,7 +61,7 @@ function RadarStepCard({
 
   return (
     <div
-      className={`rounded-2xl transition-all duration-200 overflow-hidden step-card card-depth ${isRec ? 'shadow-md' : ''}`}
+      className={`rounded-2xl transition-all duration-200 overflow-hidden step-card card-depth md:h-full md:flex md:flex-col ${isRec ? 'shadow-md' : ''}`}
       style={{
         border: cardBorder,
         background: cardBg,
@@ -87,8 +87,8 @@ function RadarStepCard({
         </div>
       )}
 
-      <div className="p-4 sm:p-6">
-        <div className="flex items-start gap-3">
+      <div className="p-4 sm:p-6 md:flex-1 md:flex md:flex-col">
+        <div className="flex items-start md:items-stretch gap-3 md:flex-1">
           {/* Icon + step number */}
           <div className="shrink-0 text-center w-10">
             <div
@@ -116,7 +116,7 @@ function RadarStepCard({
           </div>
 
           {/* Content */}
-          <div className="flex-1 min-w-0">
+          <div className="flex-1 min-w-0 md:flex md:flex-col">
             <div className="flex items-start justify-between gap-1.5">
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2 flex-wrap">
@@ -180,7 +180,7 @@ function RadarStepCard({
             {!isLocked ? (
               <button
                 onClick={onClick}
-                className={`mt-3 spring-tap font-semibold text-xs transition-all ${isRec ? 'w-full py-3 rounded-xl text-white' : hasSavedJobs ? 'py-1.5 px-3 rounded-lg' : 'py-2 px-3.5 rounded-xl'}`}
+                className={`mt-3 md:mt-auto spring-tap font-semibold text-xs transition-all ${isRec ? 'w-full py-3 rounded-xl text-white' : hasSavedJobs ? 'py-1.5 px-3 rounded-lg' : 'py-2 px-3.5 rounded-xl'}`}
                 style={isRec
                   ? { background: `linear-gradient(135deg, #c2185b, #ad1457)`, boxShadow: `0 4px 16px rgba(194,24,91,0.30)` }
                   : hasSavedJobs
@@ -196,7 +196,7 @@ function RadarStepCard({
                 }
               </button>
             ) : (
-              <p className="text-[10px] text-slate-400 mt-2">🔒 Disponible cuando tengas tu CV</p>
+              <p className="text-[10px] text-slate-400 mt-2 md:mt-auto">🔒 Disponible cuando tengas tu CV</p>
             )}
           </div>
         </div>
@@ -500,7 +500,7 @@ export default function ModeSelectScreen({
       )}
 
       {/* Journey steps */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-2 stagger-in">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 stagger-in">
         {steps.map(s => {
           const isRec    = s.num === nextRec
           const isLocked = !s.available
@@ -525,9 +525,9 @@ export default function ModeSelectScreen({
 
           // ── Generic step card ────────────────────────────────────────────
           return (
-            <div key={s.num}>
+            <div key={s.num} className="flex flex-col">
               <div
-                className={`rounded-2xl transition-all duration-200 overflow-hidden step-card card-depth ${isRec ? 'shadow-md' : ''}`}
+                className={`rounded-2xl transition-all duration-200 overflow-hidden step-card card-depth md:flex-1 md:flex md:flex-col ${isRec ? 'shadow-md' : ''}`}
                 style={{
                   border: isRec
                     ? `1.5px solid ${s.ac}`
@@ -563,8 +563,8 @@ export default function ModeSelectScreen({
                   </div>
                 )}
 
-                <div className="p-4 sm:p-6">
-                  <div className="flex items-start gap-3">
+                <div className="p-4 sm:p-6 md:flex-1 md:flex md:flex-col">
+                  <div className="flex items-start md:items-stretch gap-3 md:flex-1">
                     {/* Icon + step number */}
                     <div className="shrink-0 text-center w-10">
                       <div className="w-10 h-10 rounded-xl flex items-center justify-center text-xl"
@@ -578,7 +578,7 @@ export default function ModeSelectScreen({
                     </div>
 
                     {/* Content */}
-                    <div className="flex-1 min-w-0">
+                    <div className="flex-1 min-w-0 md:flex md:flex-col">
                       <div className="flex items-start justify-between gap-1.5">
                         <div className="flex-1 min-w-0">
                           <div className="flex items-center gap-2 flex-wrap">
@@ -618,7 +618,7 @@ export default function ModeSelectScreen({
                           <button
                             onClick={s.onClick}
                             disabled={s.num === 6 && jobAdapterCheckLoading}
-                            className={`mt-3 spring-tap font-semibold text-xs transition-all ${isRec ? 'w-full py-3 rounded-xl text-white' : s.done ? 'py-1.5 px-3 rounded-lg' : 'py-2 px-3.5 rounded-xl'}`}
+                            className={`mt-3 md:mt-auto spring-tap font-semibold text-xs transition-all ${isRec ? 'w-full py-3 rounded-xl text-white' : s.done ? 'py-1.5 px-3 rounded-lg' : 'py-2 px-3.5 rounded-xl'}`}
                             style={isRec
                               ? { background: s.ac, boxShadow: `0 4px 14px ${s.aborder}` }
                               : s.done
@@ -639,7 +639,7 @@ export default function ModeSelectScreen({
                           )}
                         </>
                       ) : (
-                        <p className="text-[10px] text-slate-400 mt-2">🔒 {s.lockedLabel}</p>
+                        <p className="text-[10px] text-slate-400 mt-2 md:mt-auto">🔒 {s.lockedLabel}</p>
                       )}
                     </div>
                   </div>

--- a/worker/index.js
+++ b/worker/index.js
@@ -3184,8 +3184,12 @@ async function fetchJobSource(source, query, location, remoteOk, env) {
     }
 
     if (source === 'serper') {
-      if (!env.SERPER_API_KEY) return { source, jobs: [], error: 'serper_not_configured' }
-      console.log(`[SERPER] query="${query}" gl=ar`)
+      if (!env.SERPER_API_KEY) {
+        console.log('[SERPER] skipped — SERPER_API_KEY not configured in this environment')
+        return { source, jobs: [], error: 'serper_not_configured' }
+      }
+      const serperT0 = Date.now()
+      console.log(`[SERPER] START query="${query}" gl=ar`)
       const r = await fetch('https://google.serper.dev/jobs', {
         method:  'POST',
         headers: { 'X-API-KEY': env.SERPER_API_KEY, 'Content-Type': 'application/json', 'User-Agent': UA },
@@ -3194,7 +3198,7 @@ async function fetchJobSource(source, query, location, remoteOk, env) {
       })
       raw = await r.json()
       const serperJobs = normalizeJobs(source, raw)
-      console.log(`[SERPER] status=${r.status} results=${serperJobs.length}`)
+      console.log(`[SERPER] status=${r.status} results=${serperJobs.length} latency=${Date.now()-serperT0}ms`)
       return { source, jobs: serperJobs }
     }
 
@@ -3227,23 +3231,29 @@ async function fetchAllSources(queries, location, remoteOk, env, userProfile = '
     fetchAtsCompanies(queries, userProfile, env),
   ])
 
-  // Collect aggregator jobs
-  const errors = {}
+  // Collect aggregator jobs + per-source result counts
+  const errors         = {}
+  const sourceCounts   = {}
   const rawAggregatorJobs = []
   for (const result of aggregatorResults) {
     if (result.error) errors[result.source] = errors[result.source] || result.error
+    if (result.jobs.length) sourceCounts[result.source] = (sourceCounts[result.source] || 0) + result.jobs.length
     for (const job of result.jobs) {
       if (job.url && job.title) rawAggregatorJobs.push(job)
     }
   }
+  if (atsJobs.length) sourceCounts['ats'] = atsJobs.length
 
   // Merge and 3-level dedup (ATS takes priority over aggregator on URL collision)
   const allJobs = deduplicateJobs([...rawAggregatorJobs, ...atsJobs])
 
-  console.log(`[RADAR:sources] aggregator=${rawAggregatorJobs.length} ats=${atsJobs.length} deduped=${allJobs.length}`)
+  console.log(`[RADAR:sources] aggregator=${rawAggregatorJobs.length} ats=${atsJobs.length} deduped=${allJobs.length} perSource=${JSON.stringify(sourceCounts)}`)
+  if (sources.includes('serper') && !sourceCounts['serper']) {
+    console.log('[SERPER] returned 0 jobs — check quota, API key validity, or search terms')
+  }
   if (Object.keys(errors).length) console.warn('[RADAR:sources] errors:', JSON.stringify(errors))
 
-  return { jobs: allJobs, sourceErrors: errors, sourcesUsed: sources }
+  return { jobs: allJobs, sourceErrors: errors, sourcesUsed: sources, sourceCounts }
 }
 
 
@@ -4382,6 +4392,7 @@ async function handleAiJobRecommendations(body, request, env, ctx, corsHeaders, 
 
   // ── Rate limit ─────────────────────────────────────────────────────────────
   const rl = await checkJobSearchRateLimit(env, user_id, ip, isPremium)
+  console.log(`[RADAR] rateLimit ok=${rl.ok} count=${rl.count}/${rl.limit} isPremium=${isPremium} identity=${user_id||ip}`)
   if (!rl.ok) {
     if (isPremium && user_id) {
       // Premium users over limit: silently serve most recent search from history.
@@ -4432,7 +4443,8 @@ async function handleAiJobRecommendations(body, request, env, ctx, corsHeaders, 
   // Format stored in KV: { jobs: NormalizedJob[], sourcesUsed: string[] }
   const KV_SOURCES_KEY = `jobs_meta:${queryHash}`
 
-  let sourcesUsed = []
+  let sourcesUsed  = []
+  let sourceCounts = {}  // per-source job counts from live fetch (empty on cache hit)
   const kvCached = await getJobsFromKV(env, queryHash)
   if (kvCached) {
     jobs      = kvCached
@@ -4442,11 +4454,12 @@ async function handleAiJobRecommendations(body, request, env, ctx, corsHeaders, 
       const metaRaw = env.RATE_LIMIT_KV ? await env.RATE_LIMIT_KV.get(KV_SOURCES_KEY) : null
       if (metaRaw) sourcesUsed = JSON.parse(metaRaw)
     } catch (e) { console.warn(`[RADAR] sourcesUsed KV recovery failed: ${e?.message} — reporting [] for pipeline_stats`) }
-    console.log(`[RADAR] jobsCache HIT — ${jobs.length} jobs from KV, sources=${sourcesUsed.length}`)
+    console.log(`[RADAR] jobsCache HIT — ${jobs.length} jobs from KV, sources=[${sourcesUsed.join(',')}] (Serper NOT called — served from cache)`)
   } else {
     // Live fetch — pass profile_text so ATS companies are selected by relevance
     const fetchResult = await fetchAllSources(cleanQueries, location, remote_ok, env, String(profile_text))
-    sourcesUsed = fetchResult.sourcesUsed || []
+    sourcesUsed  = fetchResult.sourcesUsed || []
+    sourceCounts = fetchResult.sourceCounts || {}
     if (fetchResult.jobs.length) {
       jobs = fetchResult.jobs
       await putJobsToKV(env, queryHash, jobs)
@@ -4728,13 +4741,18 @@ async function handleAiJobRecommendations(body, request, env, ctx, corsHeaders, 
   if (needsExpansion) {
     if (isPremium) {
       try {
-        console.log(`[RADAR] expansion START — generating alternative terms...`)
+        const expStartMs      = Date.now()
+        const _expTimedOut    = {}  // sentinel to distinguish timeout from null result
+        console.log(`[RADAR] expansion START — generating alternative terms... serperConfigured=${!!env.SERPER_API_KEY}`)
         const existingHashes = new Set(jobPool.map(j => canonicalJobHash(j)))
         const expandResult   = await Promise.race([
           expandWithSearch(env, ctx, cleanQueries, location, remote_ok, String(profile_text), existingHashes, requestedN, candidateLocation),
-          new Promise(r => setTimeout(() => r(null), EXPANSION_TIMEOUT_MS)),
+          new Promise(r => setTimeout(() => r(_expTimedOut), EXPANSION_TIMEOUT_MS)),
         ])
-        if (expandResult?.recommendations?.length) {
+        const expMs = Date.now() - expStartMs
+        if (expandResult === _expTimedOut) {
+          console.warn(`[RADAR] expansion TIMEOUT — exceeded ${EXPANSION_TIMEOUT_MS}ms (expMs=${expMs})`)
+        } else if (expandResult?.recommendations?.length) {
           // Merge: union of original + expansion, re-rank by match_score
           const seenHashes = new Set()
           const merged = [...recommendations, ...expandResult.recommendations]
@@ -4749,9 +4767,9 @@ async function handleAiJobRecommendations(body, request, env, ctx, corsHeaders, 
           recommendations  = merged
           expansionUsed    = true
           expansionCount   = expandResult.count
-          console.log(`[RADAR] expansion OK — +${expansionCount} new jobs merged, final=${recommendations.length}`)
+          console.log(`[RADAR] expansion OK — +${expansionCount} new jobs merged, final=${recommendations.length} expansionMs=${expMs}`)
         } else {
-          console.log(`[RADAR] expansion returned 0 new results`)
+          console.log(`[RADAR] expansion returned 0 new results expansionMs=${expMs}`)
         }
       } catch (err) {
         console.warn(`[RADAR] expansion error: ${err.message}`)
@@ -4858,7 +4876,12 @@ async function handleAiJobRecommendations(body, request, env, ctx, corsHeaders, 
       pipeline_stats: {
         premium_mode:        isPremium,
         sources_used:        sourcesUsed,
-        serper_active:       !!env.SERPER_API_KEY,
+        sources_count:       sourcesUsed.length,    // frontend reads this for "N fuentes"
+        total_evaluated:     jobPool.length,         // frontend reads this for "N avisos evaluados"
+        source_counts:       sourceCounts,          // per-source job counts (empty on cache hit)
+        serper_configured:   !!env.SERPER_API_KEY,  // env var present
+        serper_in_sources:   sourcesUsed.includes('serper'),  // actually attempted this run
+        serper_returned:     sourceCounts['serper'] || 0,     // jobs returned by Serper
         jobs_fetched:        jobs.length,
         jobs_to_gemini:      jobPool.length,
         from_jobs_cache:     fromCache,

--- a/worker/index.js
+++ b/worker/index.js
@@ -2100,7 +2100,7 @@ const JOB_SEARCH_TTL_SECS = 7_200  // job_searches row TTL (mirrors KV)
 const ATS_KV_TTL_SECS     = 79_200  // 22-hour KV cache for ATS company boards (date-keyed)
 const ATS_DB_TTL_HOURS    = 40      // ATS boards update slowly — longer DB TTL
 const JREC_KV_TTL_SECS    = 86_400  // 24-hour per-user AI score cache — skips Gemini on re-runs
-const JREC_PROMPT_VERSION = 'v7'    // bump when JOB_MATCHING_SYSTEM_PROMPT changes to bust stale KV
+const JREC_PROMPT_VERSION = 'v8'    // bump when JOB_MATCHING_SYSTEM_PROMPT changes to bust stale KV
 
 // Rate limits for *new* (fresh) searches — cached re-visits bypass these entirely.
 // Premium: 5 new searches/day — on limit, last search is served from history (silent, no block UX)
@@ -2110,7 +2110,7 @@ const JOB_SEARCH_LIMIT_PREMIUM = 5
 
 // Max jobs to send to Gemini in a single matching call (token budget guard).
 // At ~500 tokens/job snippet, 40 jobs ≈ 20 K tokens input — well within Flash Lite limits.
-const MAX_JOBS_FOR_AI_MATCHING = 40
+const MAX_JOBS_FOR_AI_MATCHING = 25
 
 // Max description length stored in job_cache (chars). Prevents >8 KB JSONB blobs.
 const MAX_DESC_CHARS = 6_000
@@ -4517,46 +4517,62 @@ async function handleAiJobRecommendations(body, request, env, ctx, corsHeaders, 
   const geminiBody = {
     system_instruction: { parts: [{ text: JOB_MATCHING_SYSTEM_PROMPT }] },
     contents,
-    generationConfig:   { temperature: 0.2, maxOutputTokens: 2048 },
+    // 4096 tokens: 25 jobs × ~150 chars/match output = ~6KB, leaves headroom for variance
+    generationConfig:   { temperature: 0.2, maxOutputTokens: 4096 },
   }
 
-  const startMs  = Date.now()
-  let   aiResult = null
-  let   aiError  = null
+  let aiResult = null
+  let aiError  = null
 
-  // 12s local timeout — Flash Lite responds in 3-5s; 12s prevents Worker CPU exhaustion
-  const geminiMatchTimeout = new Promise((_, reject) =>
-    setTimeout(() => reject(new Error('gemini_match_timeout')), 12_000)
-  )
-
-  try {
-    const aiRes = await Promise.race([
-      callGeminiApi(env, ctx, geminiBody, corsHeaders, { feature: 'job_matching_batch', userId: user_id || null }),
-      geminiMatchTimeout,
-    ])
-    // callGeminiApi returns a Response; we need to parse it for our logic
-    if (aiRes.status === 200) {
-      const aiData = await aiRes.clone().json()
-      const raw    = aiData?.candidates?.[0]?.content?.parts?.[0]?.text || ''
-      try {
-        aiResult = JSON.parse(raw.replace(/^```json\n?|\n?```$/g, '').trim())
-      } catch (parseErr) {
-        aiError = 'ai_parse_error'
-        console.warn(`[RADAR] Gemini JSON parse failed: ${parseErr.message} — raw preview: ${raw.slice(0, 200)}`)
+  // Two attempts with decreasing timeouts — Flash Lite typically responds in 3-6s.
+  // Second attempt reuses the same body; if the first timed out the second often succeeds.
+  const GEMINI_ATTEMPTS = [{ ms: 12_000 }, { ms: 8_000 }]
+  for (let attempt = 0; attempt < GEMINI_ATTEMPTS.length; attempt++) {
+    if (aiResult?.matches?.length) break
+    const t0 = Date.now()
+    try {
+      const aiRes = await Promise.race([
+        callGeminiApi(env, ctx, geminiBody, corsHeaders, { feature: 'job_matching_batch', userId: user_id || null }),
+        new Promise((_, rej) => setTimeout(() => rej(new Error('gemini_match_timeout')), GEMINI_ATTEMPTS[attempt].ms)),
+      ])
+      if (aiRes.status === 200) {
+        const aiData = await aiRes.clone().json()
+        const raw    = aiData?.candidates?.[0]?.content?.parts?.[0]?.text || ''
+        const clean  = raw.replace(/^```json\n?|\n?```$/g, '').trim()
+        try {
+          aiResult = JSON.parse(clean)
+          aiError  = null
+          console.log(`[RADAR] Gemini attempt ${attempt+1}/${GEMINI_ATTEMPTS.length} — latency=${Date.now()-t0}ms result=ok matches=${aiResult?.matches?.length||0}`)
+        } catch {
+          // Partial parse recovery: strip the truncated last object by cutting at the last complete },
+          const lastComma = clean.lastIndexOf('},')
+          if (lastComma > 10) {
+            try {
+              const partial = JSON.parse(clean.slice(0, lastComma + 1) + ']}')
+              if (partial?.matches?.length) {
+                aiResult = partial
+                aiError  = null
+                console.log(`[RADAR] Gemini attempt ${attempt+1}/${GEMINI_ATTEMPTS.length} — latency=${Date.now()-t0}ms result=partial_recovery matches=${aiResult.matches.length}`)
+                break
+              }
+            } catch { /* ignore */ }
+          }
+          aiError = 'ai_parse_error'
+          console.warn(`[RADAR] Gemini attempt ${attempt+1}/${GEMINI_ATTEMPTS.length} — latency=${Date.now()-t0}ms result=parse_error preview="${raw.slice(0, 200)}"`)
+        }
+      } else {
+        aiError = `ai_http_${aiRes.status}`
+        console.warn(`[RADAR] Gemini attempt ${attempt+1}/${GEMINI_ATTEMPTS.length} — latency=${Date.now()-t0}ms result=http_${aiRes.status}`)
       }
-    } else {
-      aiError = `ai_http_${aiRes.status}`
+    } catch (e) {
+      aiError = e.message
+      console.warn(`[RADAR] Gemini attempt ${attempt+1}/${GEMINI_ATTEMPTS.length} — latency=${Date.now()-t0}ms result=${e.message}`)
     }
-  } catch (e) {
-    aiError = e.message
-    console.warn(`[RADAR] Gemini error: ${e.message}`)
   }
 
-  console.log(`[RADAR] Gemini latency=${Date.now()-startMs}ms aiError=${aiError||'none'} matches=${aiResult?.matches?.length||0}`)
-
-  // ── Fallback: AI failed — return top jobs sorted by recency ───────────────
-  if (!aiResult?.matches || aiError) {
-    // Check for cached recommendations from a previous session
+  // ── Fallback: AI failed — heuristic scoring so cards always show a score ──
+  if (!aiResult?.matches?.length || aiError) {
+    // Tier 1: try cached recommendations from a previous session
     if (user_id) {
       try {
         const cachedRecs = await fetch(
@@ -4568,6 +4584,7 @@ async function handleAiJobRecommendations(body, request, env, ctx, corsHeaders, 
         )
         const prevRecs = await cachedRecs.json()
         if (Array.isArray(prevRecs) && prevRecs.length > 0) {
+          console.log(`[RADAR] Gemini fallback tier1 — serving ${prevRecs.length} cached recs from job_recommendations`)
           return new Response(
             JSON.stringify({
               ok:                  true,
@@ -4586,15 +4603,26 @@ async function handleAiJobRecommendations(body, request, env, ctx, corsHeaders, 
       }
     }
 
-    // No cached recs either — return top jobs without scores
-    const fallbackRecs = jobPool.slice(0, requestedN).map(j => ({
-      job:         j,
-      match_score: null,
-      strengths:   [],
-      gaps:        [],
-      summary:     'Puntuación no disponible — servicio de IA temporalmente no disponible.',
-      rec_id:      null,
-    }))
+    // Tier 2: heuristic keyword scoring — always yields a visible score on cards
+    const profileWords = new Set(
+      String(profile_text).toLowerCase().split(/\W+/).filter(w => w.length > 3)
+    )
+    const fallbackRecs = jobPool.slice(0, requestedN).map(j => {
+      const jobWords = `${j.title} ${(j.skills_required || []).join(' ')}`.toLowerCase().split(/\W+/)
+      const overlap  = jobWords.filter(w => w.length > 3 && profileWords.has(w)).length
+      const daysOld  = j.posted_at ? (Date.now() - new Date(j.posted_at).getTime()) / 86_400_000 : 30
+      const score    = Math.round(Math.min(7.5, 5.5 + Math.min(overlap, 10) * 0.15 + (daysOld < 7 ? 0.3 : 0)) * 10) / 10
+      const co       = j.company || 'esta empresa'
+      return {
+        job:         j,
+        match_score: score,
+        strengths:   [],
+        gaps:        [],
+        summary:     `Priorizando oportunidades relevantes para tu perfil en ${co}.`,
+        rec_id:      null,
+      }
+    }).sort((a, b) => b.match_score - a.match_score)
+    console.log(`[RADAR] Gemini fallback tier2 — heuristic scoring ${fallbackRecs.length} recs, aiError=${aiError}`)
     return new Response(
       JSON.stringify({
         ok:                  true,

--- a/worker/index.js
+++ b/worker/index.js
@@ -4513,6 +4513,7 @@ async function handleAiJobRecommendations(body, request, env, ctx, corsHeaders, 
   }
 
   // ── AI Matching via Gemini ─────────────────────────────────────────────────
+  const startMs    = Date.now()
   const contents   = buildMatchingContents(String(profile_text).slice(0, 3000), jobPool, candidateLocation)
   const geminiBody = {
     system_instruction: { parts: [{ text: JOB_MATCHING_SYSTEM_PROMPT }] },

--- a/worker/index.js
+++ b/worker/index.js
@@ -2103,10 +2103,10 @@ const JREC_KV_TTL_SECS    = 86_400  // 24-hour per-user AI score cache — skips
 const JREC_PROMPT_VERSION = 'v7'    // bump when JOB_MATCHING_SYSTEM_PROMPT changes to bust stale KV
 
 // Rate limits for *new* (fresh) searches — cached re-visits bypass these entirely.
-// Premium: 1 new search/day  (cached same-day results shown for free)
+// Premium: 5 new searches/day — on limit, last search is served from history (silent, no block UX)
 // Free:    1 new search/month
 const JOB_SEARCH_LIMIT_FREE    = 1
-const JOB_SEARCH_LIMIT_PREMIUM = 1
+const JOB_SEARCH_LIMIT_PREMIUM = 5
 
 // Max jobs to send to Gemini in a single matching call (token budget guard).
 // At ~500 tokens/job snippet, 40 jobs ≈ 20 K tokens input — well within Flash Lite limits.
@@ -3382,6 +3382,26 @@ async function putRadarCache(env, ctx, userId, profileHash, queryHash, recommend
   else upsert
 }
 
+// Fetch the user's most recent radar search, ignoring query hash and expiry.
+// Used to silently serve stale-but-valid results when premium daily limit is reached.
+async function getLatestRadarHistory(env, userId) {
+  if (!userId || !env.SUPABASE_SERVICE_ROLE_KEY) return null
+  try {
+    const res = await fetch(
+      `${env.SUPABASE_URL}/rest/v1/radar_search_history`
+      + `?user_id=eq.${userId}&results=not.is.null`
+      + `&order=created_at.desc&limit=1`
+      + `&select=results,top_score,match_count,created_at`,
+      { headers: { apikey: env.SUPABASE_SERVICE_ROLE_KEY, Authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}` } }
+    )
+    const rows = await res.json().catch(() => [])
+    return Array.isArray(rows) && rows[0]?.results?.length ? rows[0] : null
+  } catch (err) {
+    console.warn(`[DB] getLatestRadarHistory error for user ${userId}: ${err.message}`)
+    return null
+  }
+}
+
 /**
  * Layer 2: Upsert fresh jobs into job_cache.
  * Returns an array of { id, source, external_id } objects (the saved rows).
@@ -4363,10 +4383,37 @@ async function handleAiJobRecommendations(body, request, env, ctx, corsHeaders, 
   // ── Rate limit ─────────────────────────────────────────────────────────────
   const rl = await checkJobSearchRateLimit(env, user_id, ip, isPremium)
   if (!rl.ok) {
+    if (isPremium && user_id) {
+      // Premium users over limit: silently serve most recent search from history.
+      // This preserves the "radar is always working" UX — no wall, no "volvé mañana".
+      const historyRow = await getLatestRadarHistory(env, user_id)
+      if (historyRow?.results?.length) {
+        const histExpansionCount = historyRow.results.filter(r => r.from_expansion).length
+        console.log(`[RADAR] daily limit hit — serving history for premium ${user_id}, ${historyRow.results.length} results from ${historyRow.created_at}`)
+        return new Response(
+          JSON.stringify({
+            ok:                  true,
+            recommendations:     historyRow.results,
+            total_jobs_analyzed: historyRow.match_count || historyRow.results.length,
+            from_cache:          true,
+            cached_today:        false,
+            served_from_history: true,
+            cache_timestamp:     historyRow.created_at,
+            quota_remaining:     0,
+            expansion_used:      histExpansionCount > 0,
+            expansion_count:     histExpansionCount,
+            expansion_available: false,
+            pipeline_stats:      { cache_hit: 'history', premium_mode: true },
+          }),
+          { status: 200, headers: corsHeaders }
+        )
+      }
+    }
+    // Free users, or premium with no history at all — return 429
     return new Response(
       JSON.stringify({
         error: isPremium
-          ? `Tu búsqueda de hoy ya fue utilizada. Se renueva a las 00:00 UTC.`
+          ? `Exploraste todo lo disponible hoy. Volvé mañana para una nueva búsqueda.`
           : `Usaste tu búsqueda de este mes. Se renueva el 1 del próximo mes.`,
         quota_remaining: 0,
         next_reset:      rl.nextReset,


### PR DESCRIPTION
## Findings (multi-agent review)

**Root causes identified:**
1. Serper call was completely silent when `SERPER_API_KEY` missing — no log, no way to confirm it ran
2. `pipeline_stats.sources_count` and `total_evaluated` were never sent by backend — frontend stats line was always empty
3. `sourceCounts` per-source was never tracked — impossible to know if Serper returned 0 or 5 jobs
4. Expansion timeout returned `null` — indistinguishable from "expansion returned no results"
5. Rate limit check had zero logging — couldn't tell if `rl.ok` was true or false
6. jobsCache HIT path gave no indication Serper wasn't called (expected behavior, but silent)

## Worker fixes

- `[SERPER]` logs "skipped — SERPER_API_KEY not configured" (was completely silent before)
- `[SERPER]` logs call latency: `START query=... gl=ar` → `status=200 results=N latency=Xms`
- `fetchAllSources`: per-source result counts (`sourceCounts`) tracked and logged
- Warns if Serper was in sources but returned 0 jobs (quota/key/search issue)
- `[RADAR]` rate limit check result now logged: `ok/count/limit/isPremium/identity`
- jobsCache HIT now notes `(Serper NOT called — served from cache)`
- Expansion: sentinel object distinguishes **timeout** vs **empty result** (were both `null`)
- Expansion: `expansionMs=X` logged on OK, 0-results, and TIMEOUT paths
- Expansion START: logs `serperConfigured=` so env var state visible immediately

## pipeline_stats response fixes

| Field | Before | After |
|-------|--------|-------|
| `sources_count` | missing | `sourcesUsed.length` |
| `total_evaluated` | missing | `jobPool.length` |
| `source_counts` | missing | per-source job counts object |
| `serper_active` | env var check only | renamed `serper_configured` |
| `serper_in_sources` | missing | `sourcesUsed.includes('serper')` — actually ran |
| `serper_returned` | missing | `sourceCounts['serper'] \|\| 0` |

## Frontend — Google Jobs perception

- Captures `serper_in_sources` from `pipeline_stats` into `serperActive` state
- Header stats: shows **"Google Jobs ✓"** chip (blue) when Serper ran
- Results info box: appends "🔍 Google Jobs activado" when Serper ran
- Premium loading stage 6: "Activando expansión IA · Google Jobs · sourcing avanzado"

## Test plan

- [ ] Check Worker logs in Cloudflare: should see `[SERPER] START query=...` or `[SERPER] skipped — SERPER_API_KEY not configured`
- [ ] Fresh search (clear KV cache or new query): `pipeline_stats.serper_in_sources` should be `true` if key is set
- [ ] `pipeline_stats.sources_count` and `total_evaluated` now populate the header stats line
- [ ] If Serper ran: "Google Jobs ✓" chip appears in header and results stats
- [ ] Expansion TIMEOUT vs 0-results now distinguishable in logs

https://claude.ai/code/session_01K62FfrKMUyJxcxLkywS3oU

---
_Generated by [Claude Code](https://claude.ai/code/session_01K62FfrKMUyJxcxLkywS3oU)_