### PR TITLE
fix+improve: multi-agent review fixes + matching coverage

### DIFF
--- a/src/components/screens/JobRecommendationsScreen.jsx
+++ b/src/components/screens/JobRecommendationsScreen.jsx
@@ -755,25 +755,29 @@ function JobCard({
                 {/* Match type badge — sourced from AI headhunter scoring */}
                 {match_type === 'Directo' && (
                   <span className="px-1.5 py-0.5 rounded text-[10px] font-semibold"
-                    style={{ background: 'rgba(22,163,74,0.11)', color: '#15803d', border: '1px solid rgba(22,163,74,0.28)' }}>
+                    style={{ background: 'rgba(22,163,74,0.11)', color: '#15803d', border: '1px solid rgba(22,163,74,0.28)' }}
+                    aria-label="Match directo: tu perfil se alinea directamente con este rol">
                     ⚡ Match Directo
                   </span>
                 )}
                 {match_type === 'Adyacente' && (
                   <span className="px-1.5 py-0.5 rounded text-[10px] font-semibold"
-                    style={{ background: 'rgba(59,130,246,0.10)', color: '#1d4ed8', border: '1px solid rgba(59,130,246,0.25)' }}>
+                    style={{ background: 'rgba(59,130,246,0.10)', color: '#1d4ed8', border: '1px solid rgba(59,130,246,0.25)' }}
+                    aria-label="Match adyacente: rol en una familia profesional cercana a la tuya">
                     ↗ Match Adyacente
                   </span>
                 )}
                 {match_type === 'Transferible' && (
                   <span className="px-1.5 py-0.5 rounded text-[10px] font-semibold"
-                    style={{ background: 'rgba(245,158,11,0.10)', color: '#b45309', border: '1px solid rgba(245,158,11,0.28)' }}>
+                    style={{ background: 'rgba(245,158,11,0.10)', color: '#b45309', border: '1px solid rgba(245,158,11,0.28)' }}
+                    aria-label="Habilidades transferibles: tus competencias aplican a este rol con adaptación">
                     ↔ Transferible
                   </span>
                 )}
                 {match_type === 'Exploratorio' && (
                   <span className="px-1.5 py-0.5 rounded text-[10px] font-medium"
-                    style={{ background: 'rgba(148,163,184,0.10)', color: '#475569', border: '1px solid rgba(148,163,184,0.25)' }}>
+                    style={{ background: 'rgba(148,163,184,0.10)', color: '#475569', border: '1px solid rgba(148,163,184,0.25)' }}
+                    aria-label="Exploratorio: rol fuera de tu área principal, incluido para ampliar horizontes">
                     🔭 Exploratorio
                   </span>
                 )}

--- a/worker/index.js
+++ b/worker/index.js
@@ -3837,28 +3837,28 @@ function detectProfessionFamilySync(profileText) {
   else if (/\b(semi.?senior|ssr|mid.?level|analista\s+sr)\b/.test(t)) seniority_level = 2
   else if (/\b(junior|jr\.|trainee|pasante|entry.?level|analista\s+jr)\b/.test(t)) seniority_level = 1
 
-  if (/\b(rrhh|recursos\s+humanos|human\s+resources|hr\s+manager|hr\s+business\s+partner|hrbp|talent\s+manager|people\s+manager|gerente\s+de\s+rrhh|gerente\s+de\s+personas|capital\s+humano|nómina|payroll|talent\s+acquisition|onboarding|relaciones\s+laborales|hr\s+generalist)\b/.test(t))
+  if (/\b(rrhh|recursos\s+humanos|human\s+resources|hr\s+manager|hr\s+business\s+partner|hrbp|talent\s+manager|people\s+manager|gerente\s+de\s+rrhh|gerente\s+de\s+personas|capital\s+humano|nómina|payroll|talent\s+acquisition|onboarding|relaciones\s+laborales|hr\s+generalist|especialista\s+de\s+rrhh|analista\s+de\s+rrhh|especialista\s+en\s+recursos\s+humanos|analista\s+de\s+selecci[oó]n|analista\s+de\s+talento|people\s+business\s+partner|reclutamiento|headhunter\s+interno)\b/.test(t))
     return { family: 'HR/Personas', seniority_level, is_senior: seniority_level >= 4 }
 
-  if (/\b(software\s+engineer|desarrollador|developer|frontend|backend|fullstack|full.stack|devops|cloud\s+engineer|data\s+engineer|tech\s+lead|engineering\s+manager|ios\s+developer|android\s+dev|mobile\s+dev|arquitecto\s+de\s+software|qa\s+engineer|sre|platform\s+engineer|cto)\b/.test(t))
+  if (/\b(software\s+engineer|desarrollador|developer|frontend|backend|fullstack|full.stack|devops|cloud\s+engineer|data\s+engineer|tech\s+lead|engineering\s+manager|ios\s+developer|android\s+dev|mobile\s+dev|arquitecto\s+de\s+software|qa\s+engineer|sre|platform\s+engineer|cto|analista\s+de\s+sistemas|programador|t[eé]cnico\s+en\s+sistemas|especialista\s+en\s+ti|infrastructure\s+engineer|data\s+analyst|ml\s+engineer|machine\s+learning)\b/.test(t))
     return { family: 'Tecnología', seniority_level, is_senior: seniority_level >= 4 }
 
-  if (/\b(gerente\s+financiero|director\s+financiero|finance\s+manager|fp&a|controller|cfo|tesorería|treasury|contabl|auditor|impuestos\s+corporativos|presupuesto\s+corporativo|cash\s+flow\s+model)\b/.test(t))
+  if (/\b(gerente\s+financiero|director\s+financiero|finance\s+manager|fp&a|controller|cfo|tesorer[ií]a|treasury|contabl|auditor|impuestos\s+corporativos|presupuesto\s+corporativo|cash\s+flow\s+model|analista\s+financiero|analista\s+contable|contador\s+p[uú]blico|finanzas\s+corporativas|presupuesto|planificaci[oó]n\s+financiera|an[aá]lisis\s+financiero)\b/.test(t))
     return { family: 'Finanzas', seniority_level, is_senior: seniority_level >= 4 }
 
-  if (/\b(marketing\s+manager|brand\s+manager|growth\s+manager|performance\s+marketing|community\s+manager|content\s+manager|seo\s+manager|cmo|head\s+of\s+marketing|gerente\s+de\s+marketing)\b/.test(t))
+  if (/\b(marketing\s+manager|brand\s+manager|growth\s+manager|performance\s+marketing|community\s+manager|content\s+manager|seo\s+manager|cmo|head\s+of\s+marketing|gerente\s+de\s+marketing|especialista\s+en\s+marketing|analista\s+de\s+marketing|social\s+media|content\s+creator|email\s+marketing|growth\s+hacking|digital\s+marketing|pauta\s+digital|advertising)\b/.test(t))
     return { family: 'Marketing/Growth', seniority_level, is_senior: seniority_level >= 4 }
 
-  if (/\b(sales\s+manager|gerente\s+comercial|director\s+comercial|key\s+account|business\s+development\s+manager|head\s+of\s+sales|ejecutivo\s+comercial\s+sr|revenue\s+manager|cro)\b/.test(t))
+  if (/\b(sales\s+manager|gerente\s+comercial|director\s+comercial|key\s+account|business\s+development\s+manager|head\s+of\s+sales|ejecutivo\s+comercial|revenue\s+manager|cro|ejecutivo\s+de\s+ventas|asesor\s+comercial|representante\s+comercial|account\s+executive|ventas|vendedor|sales\s+executive|desarrollo\s+de\s+negocios)\b/.test(t))
     return { family: 'Ventas/BD', seniority_level, is_senior: seniority_level >= 4 }
 
-  if (/\b(operations\s+manager|supply\s+chain\s+manager|gerente\s+de\s+operaciones|director\s+de\s+operaciones|logística|procurement\s+manager|coo|lean\s+six\s+sigma)\b/.test(t))
+  if (/\b(operations\s+manager|supply\s+chain\s+manager|gerente\s+de\s+operaciones|director\s+de\s+operaciones|log[ií]stica|procurement\s+manager|coo|lean\s+six\s+sigma|analista\s+de\s+operaciones|coordinador\s+de\s+operaciones|especialista\s+en\s+operaciones|planner|demand\s+planning|inventory|almac[eé]n|distribuci[oó]n|cadena\s+de\s+abastecimiento)\b/.test(t))
     return { family: 'Operaciones', seniority_level, is_senior: seniority_level >= 4 }
 
-  if (/\b(abogado\s+senior|abogado\s+corporativo|lawyer|legal\s+manager|compliance\s+manager|counsel|director\s+legal|gerente\s+legal)\b/.test(t))
+  if (/\b(abogado|asesor\s+legal|analista\s+legal|paralegal|abogado\s+senior|abogado\s+corporativo|lawyer|legal\s+manager|compliance\s+manager|counsel|director\s+legal|gerente\s+legal|regulatory|normativa|due\s+diligence|contratos|litigios)\b/.test(t))
     return { family: 'Legal/Compliance', seniority_level, is_senior: seniority_level >= 4 }
 
-  if (/\b(country\s+manager|general\s+manager|director\s+general|gerente\s+general|managing\s+director|regional\s+director)\b/.test(t))
+  if (/\b(country\s+manager|general\s+manager|director\s+general|gerente\s+general|managing\s+director|regional\s+director|jefe\s+de\s+proyecto|project\s+lead|program\s+manager)\b/.test(t))
     return { family: 'Management General', seniority_level, is_senior: seniority_level >= 4 }
 
   return null
@@ -3870,11 +3870,13 @@ function buildHeadhunterQueries(professionInfo, baseQueries, isPremium) {
 
   const HEADHUNTER_MAP = {
     'HR/Personas': {
+      3: ['HR Generalist', 'Talent Acquisition Specialist', 'Analista de RRHH Sr', 'People Coordinator', 'HR Specialist'],
       4: ['HRBP', 'HR Lead', 'Jefe de RRHH', 'People Lead', 'Talent Lead'],
       5: ['Gerente de RRHH', 'HR Manager', 'Head of People', 'People Manager', 'HR Director', 'Gerente Capital Humano'],
       6: ['HR Director', 'Chief People Officer', 'VP of People', 'Director de RRHH', 'VP HR'],
     },
     'Finanzas': {
+      3: ['Senior Financial Analyst', 'Analista Financiero Sr', 'FP&A Analyst', 'Treasury Analyst Sr', 'Controller Analyst'],
       4: ['Jefe de Finanzas', 'FP&A Lead', 'Controller Senior', 'Senior Finance Analyst'],
       5: ['Gerente de Finanzas', 'Finance Manager', 'CFO', 'Director Financiero', 'Head of Finance'],
       6: ['CFO', 'Chief Financial Officer', 'VP Finance', 'Finance Director'],
@@ -3886,26 +3888,31 @@ function buildHeadhunterQueries(professionInfo, baseQueries, isPremium) {
       6: ['CTO', 'Chief Technology Officer', 'VP Engineering'],
     },
     'Marketing/Growth': {
+      3: ['Senior Marketing Analyst', 'Growth Specialist', 'Performance Specialist', 'Brand Specialist Sr', 'SEO Specialist Sr'],
       4: ['Marketing Lead', 'Growth Lead', 'Brand Manager Senior', 'Performance Lead'],
       5: ['Marketing Manager', 'Head of Marketing', 'Growth Manager', 'Director de Marketing', 'CMO'],
       6: ['CMO', 'Chief Marketing Officer', 'VP Marketing', 'Head of Brand'],
     },
     'Operaciones': {
+      3: ['Senior Operations Analyst', 'Supply Chain Specialist', 'Process Improvement Specialist', 'Analista de Operaciones Sr'],
       4: ['Operations Lead', 'Supply Chain Lead', 'Jefe de Operaciones'],
       5: ['Operations Manager', 'Head of Operations', 'Director de Operaciones', 'Supply Chain Manager'],
       6: ['COO', 'Chief Operating Officer', 'VP Operations', 'Operations Director'],
     },
     'Ventas/BD': {
+      3: ['Senior Account Executive', 'Business Development Specialist', 'Key Account Sr', 'Sales Executive Sr', 'Ejecutivo Comercial Sr'],
       4: ['Sales Lead', 'Account Manager Senior', 'Jefe de Ventas'],
       5: ['Sales Manager', 'Head of Sales', 'Director Comercial', 'Gerente Comercial', 'VP Sales'],
       6: ['Chief Revenue Officer', 'VP Sales', 'Revenue Director', 'Commercial Director'],
     },
     'Legal/Compliance': {
+      3: ['Senior Legal Analyst', 'Compliance Specialist', 'Abogado Sr', 'Regulatory Affairs Specialist'],
       4: ['Legal Counsel', 'Compliance Lead', 'Senior Legal Analyst'],
       5: ['Legal Manager', 'Head of Legal', 'Compliance Manager', 'Director Legal'],
       6: ['General Counsel', 'Chief Legal Officer', 'VP Legal'],
     },
     'Management General': {
+      3: ['Senior Project Manager', 'Program Coordinator', 'Business Analyst Sr', 'Project Lead Sr'],
       4: ['Project Manager', 'Team Lead', 'Jefe de Área'],
       5: ['General Manager', 'Country Manager', 'Director General', 'Gerente General'],
       6: ['CEO', 'Managing Director', 'COO', 'Regional Director'],
@@ -4684,7 +4691,7 @@ async function handleAiJobRecommendations(body, request, env, ctx, corsHeaders, 
   }
 
   // Kick off deep profession extraction async — runs in parallel with job fetch (~2-4s each)
-  const professionMetaPromise = extractDominantProfession(env, String(profile_text).slice(0, 1500))
+  const professionMetaPromise = extractDominantProfession(env, String(profile_text).slice(0, 2000))
 
   // ── Fetch jobs (hits cache layers before live APIs) ────────────────────────
   let   jobs         = []

--- a/worker/index.js
+++ b/worker/index.js
@@ -3471,7 +3471,7 @@ async function putRadarCache(env, ctx, userId, profileHash, queryHash, recommend
     body: JSON.stringify(row),
   }).catch(() => {})
   if (ctx?.waitUntil) ctx.waitUntil(upsert)
-  else upsert
+  else upsert.catch(err => console.warn('[RADAR] putRadarCache: ctx missing, upsert fire-and-forget:', err?.message))
 }
 
 // Fetch the user's most recent radar search, ignoring query hash and expiry.
@@ -3530,7 +3530,7 @@ Respond ONLY with JSON (no markdown):
 
   try {
     const ctrl = new AbortController()
-    const tid  = setTimeout(() => ctrl.abort(), 5_000)
+    const tid  = setTimeout(() => ctrl.abort(), 8_000)
     let res = null
     for (let ki = 0; ki < geminiKeys.length; ki++) {
       res = await fetch(
@@ -4585,8 +4585,11 @@ async function handleAiJobRecommendations(body, request, env, ctx, corsHeaders, 
   // ── Build queries — headhunter mode for premium (built here so all hashes use same queries) ──
   const baseQueriesRaw = queries.map(q => String(q).trim().slice(0, 100)).filter(Boolean).slice(0, 3)
   const headhunterActive = isPremium && !!professionInfoSync
-  // Note: cleanQueries is declared here (before caches) so queryHashEarly uses same queries as queryHash
-  // This ensures radarCache, jrecCache, and KV job cache all share the same hash key.
+  // Build cleanQueries here (before ALL cache lookups) so every cache layer uses the same hash.
+  const cleanQueries = headhunterActive
+    ? buildHeadhunterQueries(professionInfoSync, baseQueriesRaw, true)
+    : baseQueriesRaw
+  if (headhunterActive) console.log(`[RADAR] headhunterQueries: ${JSON.stringify(cleanQueries)}`)
 
   console.log(`[RADAR] START user=${user_id||'anon'} premium=${isPremium} remoteOk=${!!remote_ok} queries=${JSON.stringify(baseQueriesRaw)} location=${location||'—'}`)
 
@@ -4598,17 +4601,16 @@ async function handleAiJobRecommendations(body, request, env, ctx, corsHeaders, 
   console.log(`[RADAR] liveFetched=${liveFetched} period=${isPremium?'daily':'monthly'} user=${user_id||'anon'}`)
 
   const profileHash = user_id ? await computeProfileHash(String(profile_text)) : null
-  const cleanQueriesForHash = baseQueriesRaw
-  const queryHashEarly = user_id ? await hashQueryParams(cleanQueriesForHash, location, remote_ok) : null
+  const queryHash = user_id ? await hashQueryParams(cleanQueries, location, remote_ok) : null
 
-  if (liveFetched && user_id && profileHash && queryHashEarly) {
-    const radarCache = await getRadarCache(env, user_id, profileHash, queryHashEarly)
+  if (liveFetched && user_id && profileHash && queryHash) {
+    const radarCache = await getRadarCache(env, user_id, profileHash, queryHash)
     if (radarCache?.results?.length) {
       console.log(`[RADAR] radarCache HIT — returning ${radarCache.results.length} cached recs`)
       // Recover sourcesUsed from the KV metadata written at fetch time.
       let radarCachedSources = []
       try {
-        const metaRaw = env.RATE_LIMIT_KV ? await env.RATE_LIMIT_KV.get(`jobs_meta:${queryHashEarly}`) : null
+        const metaRaw = env.RATE_LIMIT_KV ? await env.RATE_LIMIT_KV.get(`jobs_meta:${queryHash}`) : null
         if (metaRaw) radarCachedSources = JSON.parse(metaRaw)
       } catch (e) { console.warn('[RADAR] radarCache: failed to recover sourcesUsed from KV:', e?.message) }
       // Derive expansion fields from cached results so the frontend shows correct badges
@@ -4681,17 +4683,10 @@ async function handleAiJobRecommendations(body, request, env, ctx, corsHeaders, 
     )
   }
 
-  // ── Build final queries — headhunter mode expands base with profession-targeted titles ──
-  const cleanQueries = headhunterActive
-    ? buildHeadhunterQueries(professionInfoSync, baseQueriesRaw, true)
-    : baseQueriesRaw
-  if (headhunterActive) console.log(`[RADAR] headhunterQueries: ${JSON.stringify(cleanQueries)}`)
-
   // Kick off deep profession extraction async — runs in parallel with job fetch (~2-4s each)
   const professionMetaPromise = extractDominantProfession(env, String(profile_text).slice(0, 1500))
 
   // ── Fetch jobs (hits cache layers before live APIs) ────────────────────────
-  const queryHash    = await hashQueryParams(cleanQueries, location, remote_ok)
   let   jobs         = []
   let   fromCache    = false
 
@@ -4858,7 +4853,7 @@ async function handleAiJobRecommendations(body, request, env, ctx, corsHeaders, 
           `${env.SUPABASE_URL}/rest/v1/job_recommendations`
           + `?user_id=eq.${user_id}&status=neq.dismissed`
           + `&order=match_score.desc&limit=${requestedN}`
-          + `&select=id,title,company,location,remote,url,match_score,strengths,gaps,summary,source,status`,
+          + `&select=id,title,company,location,remote,url,match_score,match_type,strengths,gaps,summary,source,status`,
           { headers: { apikey: env.SUPABASE_SERVICE_ROLE_KEY, Authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}` } }
         )
         const prevRecs = await cachedRecs.json()
@@ -4867,7 +4862,7 @@ async function handleAiJobRecommendations(body, request, env, ctx, corsHeaders, 
           return new Response(
             JSON.stringify({
               ok:                  true,
-              recommendations:     prevRecs.map(r => ({ job: r, match_score: r.match_score, strengths: r.strengths, gaps: r.gaps, summary: r.summary, rec_id: r.id })),
+              recommendations:     prevRecs.map(r => ({ job: r, match_score: r.match_score, match_type: r.match_type || null, strengths: r.strengths, gaps: r.gaps, summary: r.summary, rec_id: r.id })),
               total_jobs_analyzed: 0,
               from_cache:          true,
               fallback:            true,
@@ -4895,6 +4890,7 @@ async function handleAiJobRecommendations(body, request, env, ctx, corsHeaders, 
       return {
         job:         j,
         match_score: score,
+        match_type:  null,
         strengths:   [],
         gaps:        [],
         summary:     `Priorizando oportunidades relevantes para tu perfil en ${co}.`,


### PR DESCRIPTION
## Fixes (del review)
- **Critical**: queryHash mismatch — radarCache ahora usa el mismo hash que KV/jrecCache (headhunter queries). Antes premium nunca acertaba el radarCache.
- **Medium**: `match_type` agregado a fallbacks tier1/tier2 y al select de Supabase
- **Low**: Dead code `else upsert` en putRadarCache → `.catch()` logging
- **Low**: `extractDominantProfession` timeout 5s → 8s

## Mejoras de cobertura
- `detectProfessionFamilySync`: +20 títulos LATAM comunes por familia (especialista, ejecutivo comercial, analista de RRHH, contador público, social media, planner, abogado, etc.)
- `buildHeadhunterQueries`: level 3 (Senior/Especialista) para las 7 familias que lo tenían vacío — semi-seniors premium ya no usan queries de manager
- Profile slice `extractDominantProfession`: 1500 → 2000 chars
- Badges `match_type`: `aria-label` descriptivos en los 4 tipos

https://claude.ai/code/session_01K62FfrKMUyJxcxLkywS3oU

---
_Generated by [Claude Code](https://claude.ai/code/session_01K62FfrKMUyJxcxLkywS3oU)_